### PR TITLE
chore: Update site configuration and remove Disqus comments

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,8 @@ baseURL = ""
 title = "Salgado lab"
 theme = "educenter-hugo"
 # post pagination
-paginate = "6"
+[pagination]
+  pagerSize = 6
 # post excerpt
 summaryLength = "10"
 # disqus short name
@@ -130,8 +131,9 @@ languageName = "En"
 languageCode = "en-us"
 contentDir = "content/english"
 weight = 1
-home = "Home"
-url = "/"
+[Languages.en.params]
+  home = "Home"
+  url = "/"
 # copyright
 copyright = "Copyright &copy; 2021 Paula Salgado"
 
@@ -177,7 +179,8 @@ languageName = "Fr"
 languageCode = "fr-fr"
 contentDir = "content/french"
 weight = 2
-home = "Accueil"
+[Languages.fr.params]
+  home = "Accueil"
 # copyright
 copyright = "Copyright &copy; 2021 Institute for Cell and Molecular Biosciences"
 
@@ -258,3 +261,6 @@ url = "scholarship"
 [[Languages.fr.menu.footer]]
 name = "research"
 url = "research"
+
+[services.disqus]
+  shortname = "yourshortname"

--- a/themes/educenter-hugo/layouts/_default/single.html
+++ b/themes/educenter-hugo/layouts/_default/single.html
@@ -33,12 +33,6 @@
           <div class="col-12 mb-5">
             {{ .Content }}
           </div>
-          <!-- comments -->
-          {{ if site.DisqusShortname }}
-          <div class="col-12">
-            {{ template "_internal/disqus.html" . }}
-          </div>
-          {{ end }}
         </div>
       </div>
       {{ partial "blog-sidebar.html" . }}


### PR DESCRIPTION
Fix Hugo 0.134.2 deprecations:

```
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
ERROR deprecated: config: languages.en.url: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.135.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.en.home: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.135.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
ERROR deprecated: config: languages.fr.home: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.135.0. Put the value below [languages.fr.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
Watching for changes in /home/rui/Sync/code/sites/salgado-lab/{archetypes,content,data,i18n,layouts,static,themes}
Watching for config changes in /home/rui/Sync/code/sites/salgado-lab/config.toml
Start building sites … 
hugo v0.134.2+extended linux/amd64 BuildDate=2024-09-10T10:46:33Z VendorInfo=brew

ERROR deprecated: .Site.DisqusShortname was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.Disqus.Shortname instead.
Built in 349 ms
Error: error building site: logged 1 error(s)
```